### PR TITLE
mapping between common names and scientific names

### DIFF
--- a/USDA/usda_json.py
+++ b/USDA/usda_json.py
@@ -2,6 +2,7 @@ import os
 import re
 import json
 import subprocess
+from collections import defaultdict
 
 import numpy as np
 import pandas as pd
@@ -112,6 +113,13 @@ def usda_dicts(df):
     assert df.shape[0] == len(usda)
     return nested_dict(usda)
 
+def mapping(df):
+    df = df.copy()
+    names_mapping = defaultdict(list)
+    for i in df.index:
+        names_mapping[df.common_name[i]].append(df.scientific_name[i])
+    return dict(names_mapping)
+
 def to_json(d, filename):
     """Dictionary to JSON
 
@@ -143,8 +151,9 @@ def to_json(d, filename):
 def main():
     df = data(usda_file)
     usda_json = usda_dicts(df)
-    to_json(usda_json, 'test.json')
-    
+    to_json(usda_json, 'usda.json')
+    names_map = mapping(df)
+    to_json(names_map, 'mapping.json')
 
 
 if __name__ == '__main__':
@@ -153,6 +162,8 @@ if __name__ == '__main__':
     if args:
         if argv[1] == 'create':
             main()
+        else:
+            print("'{}' is not a valid argument".format(argv[1]))
     else:
         import doctest
         doctest.testmod()

--- a/USDA/usda_json.py
+++ b/USDA/usda_json.py
@@ -5,6 +5,8 @@ import numpy as np
 import pandas as pd
 
 
+usda_file = 'usda_plant2.csv'
+
 def normalize(s):
     """Removes text within angled brackets
     Removes commas, parens, and degree symbols
@@ -67,7 +69,8 @@ def nested_dict(dicts):
 
     Example
     -------
-    >>> x = [{'scientific_name' : 'a', 'something' : 2}, {'scientific_name' : 'b', 'something' : 3}]
+    >>> x = [{'scientific_name' : 'a', 'something' : 2},
+    ...      {'scientific_name' : 'b', 'something' : 3}]
     >>> d = nested_dict(x)
     >>> sorted(d.keys())
     ['a', 'b']
@@ -77,7 +80,7 @@ def nested_dict(dicts):
 
 def usda_dicts():
     """Convert the USDA data to a nested dictionary"""
-    df = pd.read_csv('usda_plant2.csv')
+    df = pd.read_csv(usda_file)
     cols_orig = df.columns
     df.columns = [normalize(c) for c in cols_orig]
     usda = df.to_dict(orient='record')
@@ -87,8 +90,13 @@ def usda_dicts():
 
 
 if __name__ == '__main__':
-    import doctest
-    doctest.testmod()
-    j = usda_dicts()
-    with open('usda.json', 'w') as f:
-        json.dump(j, f, indent=4)
+    from sys import argv
+    args = len(argv) > 1
+    if args:
+        if argv[1] == 'create':
+            j = usda_dicts()
+            with open('usda.json', 'w') as f:
+                json.dump(j, f, indent=4)
+    else:
+        import doctest
+        doctest.testmod()


### PR DESCRIPTION
This creates a new JSON file (`mapping.json`) from common names to scientific names. Example:

```
{
    "monk orchid": [
        "Oeceoclades",
        "Oeceoclades maculata"
    ],
    "eranthis": [
        "Eranthis"
    ],
    "Hoosier Pass ipomopsis": [
        "Ipomopsis globularis"
    ]
}
```

We'll still need to edit this a little. For example, there are several rows with missing (`NaN`) common names. Perhaps we might also want to lower case everything, too.

**To _create_ the JSON files**:

```
$ python usda_json.py create
```
